### PR TITLE
Fix HttpClientRequestMessage.cs

### DIFF
--- a/src/Microsoft.OData.Extensions.Client.Abstractions/Microsoft.OData.Extensions.Client.Abstractions.csproj
+++ b/src/Microsoft.OData.Extensions.Client.Abstractions/Microsoft.OData.Extensions.Client.Abstractions.csproj
@@ -9,7 +9,7 @@
   <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
       <NuspecProperties>ProductRoot=$(productBinPath);version=$(VERSION_SEMANITCS_CLIENT_ABSTRACTIONS)</NuspecProperties>
-      <NuspecProperties>$(NuspecProperties);ODataClientPackageDependency=7.6.0</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);ODataClientPackageDependency=7.7.0</NuspecProperties>
     </PropertyGroup>
   </Target>
   <Import Project="..\Build.props" />
@@ -18,6 +18,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OData.Client" Version="7.6.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="HttpClientRequestMessage.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -307,7 +307,7 @@ namespace Microsoft.OData.Extensions.Client
                 {
                     var send = CreateSendTask();
                     send.Wait();
-                    return ConvertHttpClientResponse(send.Result);
+                    return new HttpClientResponseMessage(send.Result, this.config);
                 });
         }
 #endif

--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -299,6 +299,18 @@ namespace Microsoft.OData.Extensions.Client
         {
             return UnwrapAggregateException(() => new HttpClientResponseMessage(((Task<HttpResponseMessage>)asyncResult).Result, this.config));
         }
+        
+#if !PORTABLELIB && !(NETCOREAPP1_0 || NETCOREAPP2_0)
+        public override IODataResponseMessage GetResponse()
+        {
+            return UnwrapAggregateException(() =>
+                {
+                    var send = CreateSendTask();
+                    send.Wait();
+                    return ConvertHttpClientResponse(send.Result);
+                });
+        }
+#endif
 
         /// <summary>
         /// Dispose the object.

--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -300,7 +300,7 @@ namespace Microsoft.OData.Extensions.Client
             return UnwrapAggregateException(() => new HttpClientResponseMessage(((Task<HttpResponseMessage>)asyncResult).Result, this.config));
         }
         
-#if !PORTABLELIB && !(NETCOREAPP1_0 || NETCOREAPP2_0)
+#if !(NETCOREAPP1_0 || NETCOREAPP2_0)
         public override IODataResponseMessage GetResponse()
         {
             return UnwrapAggregateException(() =>

--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -150,6 +150,51 @@ namespace Microsoft.OData.Extensions.Client
                 this.requestMessage.Properties[typeof(ICredentials).FullName] = value;
             }
         }
+        
+        /// <summary>
+        /// Gets or sets the timeout (in seconds) for this request.
+        /// </summary>
+        public override int Timeout 
+        { 
+            get
+            {
+                return (int)this.client.Timeout.TotalSeconds;
+            }
+            set
+            {
+                this.client.Timeout = new TimeSpan(0, 0, value);
+            }
+        }
+
+        public override int ReadWriteTimeout
+        {
+            get
+            {
+                return (int)this.client.Timeout.TotalSeconds;
+            }
+            set
+            {
+                this.client.Timeout = new TimeSpan(0, 0, value);
+            }
+        }
+
+#if !(NETCOREAPP1_0 || NETCOREAPP2_0)
+        /// <summary>
+        /// Gets or sets a value that indicates whether to send data in segments to the Internet resource. 
+        /// </summary>
+        public override bool SendChunked
+        {
+            get
+            {
+                bool? transferEncodingChunked = this.requestMessage.Headers.TransferEncodingChunked;
+                return transferEncodingChunked.HasValue && transferEncodingChunked.Value;
+            }
+            set
+            {
+                this.requestMessage.Headers.TransferEncodingChunked = value;
+            }
+        }
+#endif
 
         /// <summary>
         /// Returns the value of the header with the given name.

--- a/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
+++ b/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OData.Client" Version="7.6.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
+++ b/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.OData.Edm" Version="7.7.0" />
     <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
   </ItemGroup>
 

--- a/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
+++ b/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.OData.Edm" Version="7.7.0" />
+    <PackageReference Include="System.Text.Json" Version="4.7.1" />
     <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
   </ItemGroup>
 

--- a/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
+++ b/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.OData.Client" Version="7.6.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />


### PR DESCRIPTION
DataServiceClientRequestMessage contracts have changed (https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs).
Sync it to https://github.com/OData/odata.net/blob/master/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs.

More details in issue https://github.com/OData/Extensions/issues/37