### PR TITLE
Update dependencies range to [2.1.0,5.0.0)

### DIFF
--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -11,9 +11,9 @@
   <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
     <ODataClientPackageDependency>[7.5.1.0, 8.0.0)</ODataClientPackageDependency>
-    <ExtensionsDependencyInjectionDependency>[2.1.0,4.0.0)</ExtensionsDependencyInjectionDependency>
-    <ExtensionsOptionsDependency>[2.1.0,4.0.0)</ExtensionsOptionsDependency>
-    <ExtensionsHttpDependency>[2.1.0,4.0.0)</ExtensionsHttpDependency>
+    <ExtensionsDependencyInjectionDependency>[2.1.0,5.0.0)</ExtensionsDependencyInjectionDependency>
+    <ExtensionsOptionsDependency>[2.1.0,5.0.0)</ExtensionsOptionsDependency>
+    <ExtensionsHttpDependency>[2.1.0,5.0.0)</ExtensionsHttpDependency>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Hello,
We get a dependency warning when using this library in a .Net5 project.

```
warning NU1608: Version du package détectée en dehors de la contrainte de dépendance : Microsoft.OData.Extensions.Client 1.0.2 nécessite Microsoft.Extensions.DependencyInjection (>= 2.1.0 && < 4.0.0) alors que la version Microsoft.Extensions.DependencyInjection 5.0.0 a été résolue.
```

Sorry, the build warning is in french  🇫🇷 