### PR TITLE
[V3] Override abstract fields in HttpClientRequestMessage

### DIFF
--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -166,9 +166,7 @@ namespace Microsoft.OData.Extensions.V3Client
                 this.client.Timeout = new TimeSpan(0, 0, value);
             }
         }
-#endif
 
-#if !ASTORIA_LIGHT && !PORTABLELIB
         /// <summary>
         /// Gets or sets a value that indicates whether to send data in segments to the Internet resource. 
         /// </summary>


### PR DESCRIPTION
Services targeting .net framework are getting the following error when trying to use Extensions for V3 clients.

```
System.TypeLoadException: Method 'get_Timeout' in type 'Microsoft.OData.Extensions.V3Client.HttpClientRequestMessage' from assembly 'Microsoft.OData.Extensions.V3Client, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35' does not have an implementation.
```

This is because the net40 target of ODataLib V3 exposes additional abstract fields in `DataServiceClientRequestMessage`. See https://github.com/OData/odata.net/blob/maintenance-5.x/WCFDataService/Client/System/Data/Services/Client/Serialization/DataServiceClientRequestMessage.cs

The fix is similar to #43 . 