### PR TITLE
Multi-target net462 to support .net framework projects

### DIFF
--- a/src/Build.props
+++ b/src/Build.props
@@ -4,8 +4,8 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
 
-    <!-- target 2.0 only for library project.-->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- target netstandard2.0 and net462 for library project.-->
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
 
     <!-- Global settings that apply unconditionally. -->
     <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.root))\</EnlistmentRoot>

--- a/src/Microsoft.OData.Extensions.Client.Abstractions/OData.V3Client.Abstractions.csproj
+++ b/src/Microsoft.OData.Extensions.Client.Abstractions/OData.V3Client.Abstractions.csproj
@@ -10,4 +10,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Extensions.Client/Internals/Handlers/HttpClientRequestMessage.cs
@@ -151,7 +151,7 @@ namespace Microsoft.OData.Extensions.V3Client
             }
         }
 
-#if !ASTORIA_LIGHT && !PORTABLELIB
+#if NET462
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
@@ -288,7 +288,7 @@ namespace Microsoft.OData.Extensions.V3Client
             return UnwrapAggregateException(() => new HttpClientResponseMessage(((Task<HttpResponseMessage>)asyncResult).Result, this.config));
         }
 
-#if !ASTORIA_LIGHT && !PORTABLELIB
+#if NET462
         /// <summary>
         /// Returns a response from an Internet resource.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net462</TargetFrameworks>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>


### PR DESCRIPTION
A follow-up of #52 .

The reason to add net462 as a target framework is that it enables support for .net framework projects.