### PR TITLE
Remove version upper bound for Microsoft.Extensions dependencies

### DIFF
--- a/tools/WebStack.versions.settings.targets
+++ b/tools/WebStack.versions.settings.targets
@@ -5,16 +5,16 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">1</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
-    <VersionBuild Condition="'$(VersionBuild)' == ''">4</VersionBuild>
+    <VersionBuild Condition="'$(VersionBuild)' == ''">5</VersionBuild>
     <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
   </PropertyGroup>
 
   <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
     <ODataClientPackageDependency>[5.8.4, 6.0.0)</ODataClientPackageDependency>
-    <ExtensionsDependencyInjectionDependency>[2.1.0,4.0.0)</ExtensionsDependencyInjectionDependency>
-    <ExtensionsOptionsDependency>[2.1.0,4.0.0)</ExtensionsOptionsDependency>
-    <ExtensionsHttpDependency>[2.1.0,4.0.0)</ExtensionsHttpDependency>
+    <ExtensionsDependencyInjectionDependency>[2.1.0,)</ExtensionsDependencyInjectionDependency>
+    <ExtensionsOptionsDependency>[2.1.0,)</ExtensionsOptionsDependency>
+    <ExtensionsHttpDependency>[2.1.0,)</ExtensionsHttpDependency>
   </PropertyGroup>
 
   <!--

--- a/tools/WebStack.versions.settings.targets
+++ b/tools/WebStack.versions.settings.targets
@@ -12,9 +12,9 @@
   <!-- For NuGet Package Dependencies -->
   <PropertyGroup>
     <ODataClientPackageDependency>[5.8.4, 6.0.0)</ODataClientPackageDependency>
-    <ExtensionsDependencyInjectionDependency>[2.1.0,)</ExtensionsDependencyInjectionDependency>
-    <ExtensionsOptionsDependency>[2.1.0,)</ExtensionsOptionsDependency>
-    <ExtensionsHttpDependency>[2.1.0,)</ExtensionsHttpDependency>
+    <ExtensionsDependencyInjectionDependency>2.1.0</ExtensionsDependencyInjectionDependency>
+    <ExtensionsOptionsDependency>2.1.0</ExtensionsOptionsDependency>
+    <ExtensionsHttpDependency>2.1.0</ExtensionsHttpDependency>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
This is needed to resolve NU1608 warnings for .NET 5 and .NET 6 projects.

```
Microsoft.OData.Extensions.V3Client 1.0.4 requires Microsoft.Extensions.DependencyInjection (>= 2.1.0 && < 4.0.0) but version Microsoft.Extensions.DependencyInjection 6.0.0 was resolved.
```

