### PR TITLE
Upgrade Microsoft.NetCore.Jit dependency

### DIFF
--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" />
   <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" />
   <package id="Microsoft.NETCore.App" version="1.0.0" />
-  <package id="Microsoft.NETCore.Jit" version="1.0.2" />
+  <package id="Microsoft.NETCore.Jit" version="1.1.13" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
   <package id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
   <package id="Newtonsoft.Json" version="6.0.5" />

--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" />
   <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" />
-  <package id="Microsoft.NETCore.App" version="1.0.0" />
+  <package id="Microsoft.NETCore.App" version="2.1.30" />
   <package id="Microsoft.NETCore.Jit" version="1.1.13" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
   <package id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
@@ -22,7 +22,7 @@
   <package id="xunit.extensibility.execution" version="2.1.0" />
   <package id="xunit.runner.visualstudio" version="2.1.0" />
 
-  <!--Below packages are used by Microsoft.OData.ExtensionsClient-->
+  <!--Below packages are used by Microsoft.OData.Extensions.Client-->
   <package id="Microsoft.Extensions.DependencyInjection" version="2.1.0" />
   <package id="Microsoft.Extensions.Options" version="2.1.0" />
   <package id="Microsoft.Extensions.Http" version="2.1.0" />

--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -7,7 +7,6 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="1.0.0" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" />
   <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" />
-  <package id="Microsoft.NETCore.App" version="2.1.30" />
   <package id="Microsoft.NETCore.Jit" version="1.1.13" />
   <package id="Microsoft.NETCore.Portable.Compatibility" version="1.0.1" />
   <package id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />

--- a/src/Microsoft.OData.Extensions.Client.Abstractions/Microsoft.OData.Extensions.Client.Abstractions.csproj
+++ b/src/Microsoft.OData.Extensions.Client.Abstractions/Microsoft.OData.Extensions.Client.Abstractions.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
+++ b/test/EndToEndTests/GeneratedClient/ODataVerificationClient/ODataVerificationClient.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
-    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
+++ b/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />

--- a/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
+++ b/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
@@ -1,15 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.2.1" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.18" />
   </ItemGroup>
 
 </Project>

--- a/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
+++ b/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.2.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
-  </ItemGroup>
-
 </Project>

--- a/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
+++ b/test/EndToEndTests/Services/ODataVerificationService/ODataVerificationService.csproj
@@ -12,4 +12,8 @@
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.2.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+  </ItemGroup>
+
 </Project>

--- a/test/EndToEndTests/Services/ODataVerificationService/Startup.cs
+++ b/test/EndToEndTests/Services/ODataVerificationService/Startup.cs
@@ -28,8 +28,11 @@ namespace ODataVerificationService
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services
+                .AddMvc(options => options.EnableEndpointRouting = false)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                .AddApplicationPart(this.GetType().Assembly);
             services.AddOData();
-            services.AddMvc().SetCompatibilityVersion(CompatibilityVersion.Version_2_1);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/EndToEndTests/Services/ODataVerificationService/Startup.cs
+++ b/test/EndToEndTests/Services/ODataVerificationService/Startup.cs
@@ -30,13 +30,13 @@ namespace ODataVerificationService
         {
             services
                 .AddMvc(options => options.EnableEndpointRouting = false)
-                .SetCompatibilityVersion(CompatibilityVersion.Version_2_2)
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddApplicationPart(this.GetType().Assembly);
             services.AddOData();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             app.UseMvc(b =>
             {

--- a/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
+++ b/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
@@ -35,4 +35,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+  </ItemGroup>
+
 </Project>

--- a/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
+++ b/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
@@ -35,8 +35,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
-  </ItemGroup>
-
 </Project>

--- a/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
+++ b/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
@@ -3,20 +3,19 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.E2ETests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.E2ETests</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.OData.Client" Version="7.7.3" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.12.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.30" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
+++ b/test/EndToEndTests/Tests/Microsoft.OData.Extensions.Client.E2ETests/OData.Client.E2ETests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.E2ETests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.E2ETests</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>false</SignAssembly>
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="Microsoft.OData.Client" Version="7.7.0" />
+    <PackageReference Include="Microsoft.OData.Client" Version="7.7.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.1" />

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
@@ -29,4 +29,8 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+  </ItemGroup>
+
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>
@@ -27,10 +27,6 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
   </ItemGroup>
 
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Client.Tests/OData.Client.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Client.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Client.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <!-- Disable GenerateAssemblyInfo to use the existing AssemblyInfo.cs -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/BodyTranslationTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/BodyTranslationTest.cs
@@ -118,7 +118,7 @@ namespace Microsoft.OData.Extensions.Migration.Tests
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             JObject json = (JObject)JToken.Parse(content);
             DateTime customer1BirthDate = DateTime.Parse(json["value"][0]["DateTimeOfBirth"].ToString());
-            Assert.Equal("1/1/2000 12:00:00 AM", customer1BirthDate.ToString());
+            Assert.Equal("1/1/2000 12:00:00 AM", customer1BirthDate.ToString("M'/'d'/'yyyy hh:mm:ss tt"));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
@@ -36,4 +36,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
+  </ItemGroup>
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Migration.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Migration.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Migration.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Migration.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>
@@ -11,10 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.30" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.NETCore.Portable.Compatibility" Version="1.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Extensions.Migration.Tests/Microsoft.OData.Extensions.Migration.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Extensions.Migration.Tests</AssemblyName>
     <RootNamespace>Microsoft.OData.Extensions.Migration.Tests</RootNamespace>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>
@@ -35,9 +35,5 @@
     <None Update="V3ODataSvc.edmx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Update="Microsoft.NETCore.App" Version="2.1.30" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Issues

*This pull request fixes https://github.com/OData/Extensions/security/dependabot/3.*

**.NET Core 1.0, .NET Core 1.1, NET Core 2.0 and PowerShell Core 6.0.0 allow a denial of Service vulnerability due to how specially crafted requests are handled, aka ".NET Core Denial of Service Vulnerability"**

The issue could only be fixed by upgrading the test projects specifically to .NET Core 3.1 and that necessitated a bunch of fixes here and there. However, other than for **Microsoft.OData.Extensions.Client.Abstractions**, all the other changes affect test projects

### Description

Fixes .NET Core Denial of Service Vulnerability reported here https://github.com/OData/Extensions/security/dependabot/3